### PR TITLE
Fix ARM

### DIFF
--- a/runtime-benchmarks/raytrace/Cargo.toml
+++ b/runtime-benchmarks/raytrace/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Jason Orendorff <jason.orendorff@gmail.com>"]
 
 [dependencies]
 rand = "0.3.14"
-lodepng = "0.5.1"
+lodepng = "0.5.3"


### PR DESCRIPTION
`lodepng` has been [fixed](https://github.com/pornel/lodepng-rust/pull/12) and `0.5.3` now compiles on ARM.
